### PR TITLE
Fix for click event when launched for modal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-google-place",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/israelidanny/ion-google-place",
   "authors": [
     "Danny Povolotski <dannypovolotski@gmail.com>"

--- a/ion-google-place.js
+++ b/ion-google-place.js
@@ -25,7 +25,7 @@ angular.module('ion-google-place', [])
                     var searchEventTimeout = undefined;
 
                     var POPUP_TPL = [
-                        '<div class="ion-google-place-container">',
+                        '<div class="ion-google-place-container modal">',
                             '<div class="bar bar-header item-input-inset">',
                                 '<label class="item-input-wrapper">',
                                     '<i class="icon ion-ios7-search placeholder-icon"></i>',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ion-google-place",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ion-google-place ================",
   "main": "ion-google-place.js",
   "directories": {


### PR DESCRIPTION
Popup click events were not working when launched from a modal.

Added `modal` class to ion-google-place-container fixes the issue.

Fix is based on recommendation from [Issue #4](https://github.com/israelidanny/ion-google-place/issues/4)

