### PR TITLE
Fix model value can not reload and display the address problem

### DIFF
--- a/ion-google-place.js
+++ b/ion-google-place.js
@@ -187,6 +187,8 @@ angular.module('ion-google-place', [])
 
                     ngModel.$formatters.unshift(function (modelValue) {
                         if (!modelValue) return '';
+                        if (modelValue == "[object Object]") // Ionic string formatter lost model data
+                          return ngModel.$modelValue;
                         return modelValue;
                     });
 


### PR DESCRIPTION
At least on my ionic 1.2.4, the ionic input string $formatter will convert the modelvalue first to string, which will cause the ion-google-place can not display the address, with the model value exact the previous valid value set from the directive.

This fix will recover the raw model object value, then it can display the address correctly.