### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ionic directive for a location dropdown that utilizes google maps
 
 This is a simple directive for an autocomplete overlay location field built for Ionic Framework.
 
-#Installation
+# Installation
 
 Installation should be dead simple, you can grab a copy from bower:
 ```bash


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
